### PR TITLE
Fix type in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@ authors:
 dependencies:
   "ansible.netcommon": "*"
 license_file: LICENSE
-name: skydive
-namespace: skydive
+name: frr
+namespace: frr
 readme: README.rst
-repository: https://github.com/ansible-collections/skydive
+repository: https://github.com/ansible-collections/frr


### PR DESCRIPTION
This is frr.frr, not skydive.skydive.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>