### PR TITLE
Remove ansible as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-ansible


### PR DESCRIPTION
In 2.11 ansible is called ansible-core and
this requirement should already be fulfilled to run ansible code
so is a given

